### PR TITLE
refactor logback.ContextSelector to juli-logback.ContextSelector

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -152,6 +152,7 @@
 			<replacefilter token="ch.qos.logback" value="org.apache.juli.logging.ch.qos.logback" />
 			<replacefilter token="ch/qos/logback" value="org/apache/juli/logging/ch/qos/logback" />
 			<replacefilter token="&quot;logback.configurationFile&quot;" value="&quot;juli-logback.configurationFile&quot;" />
+			<replacefilter token="logback.ContextSelector" value="juli-logback.ContextSelector" />
 		</replace>
 		<mkdir dir="${logback-classic.home}/logback-classic-${logback.version}-sources/org/apache/juli/logging/ch" />
 		<move todir="${logback-classic.home}/logback-classic-${logback.version}-sources/org/apache/juli/logging/ch">


### PR DESCRIPTION
I needed to rewrite this property for the same reason you rewrite logback.configurationFile. I use a JNDI context selector for my applications, but when Tomcat sees logback.ContextSelector at startup, it throws an NPE.
