### PR TITLE
Updated Dependencies / Removed invalid repo info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,10 +67,10 @@
         <janino.version>2.6.1</janino.version>
         <jansi.version>1.11</jansi.version>
         <jms.version>3.1.2.2</jms.version>
-        <logback.version>1.1.1</logback.version>
+        <logback.version>1.1.2</logback.version>
         <mail.version>1.5.1</mail.version>
         <slf4j.version>1.7.6</slf4j.version>
-        <tomcat.version>7.0.52</tomcat.version>
+        <tomcat.version>7.0.53</tomcat.version>
     </properties>
     <dependencies>
         <dependency>
@@ -129,30 +129,6 @@
             <version>${jansi.version}</version>
         </dependency>
     </dependencies>
-    <repositories>
-        <repository>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <id>central</id>
-            <url>http://central</url>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <id>central</id>
-            <url>http://central</url>
-        </pluginRepository>
-    </pluginRepositories>
     <build>
         <finalName>tomcat-juli</finalName>
         <pluginManagement>


### PR DESCRIPTION
Updated logback to 1.1.2
Updated tomcat to 7.0.53
Removed bogus repo info that caused serious issues when no local nexus
repo.  Builds essentially failed until this was removed and repo was
completely cleared.
