### PR TITLE
Removed allow snapshots

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -557,9 +557,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
-                <configuration>
-                    <allowSnapshots>true</allowSnapshots>
-                </configuration>
             </plugin>
         </plugins>
     </reporting>


### PR DESCRIPTION
versions plugin shouldn't allow snapshots since they change way too
often.
