### PR TITLE
[logback] Add support for logback 1.2.x - Fixes #146

### DIFF
--- a/tomcat7/pom.xml
+++ b/tomcat7/pom.xml
@@ -78,6 +78,14 @@
                                         <exclude>META-INF/services/**</exclude>
                                     </excludes>
                                 </filter>
+
+                                <!-- Exclude services from logback-classic as we redefine them -->
+                                <filter>
+                                    <artifact>ch.qos.logback:logback-classic</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/services/**</exclude>
+                                    </excludes>
+                                </filter>
                             </filters>
 
                             <relocations>

--- a/tomcat8/pom.xml
+++ b/tomcat8/pom.xml
@@ -78,6 +78,14 @@
                                         <exclude>META-INF/services/**</exclude>
                                     </excludes>
                                 </filter>
+
+                                <!-- Exclude services from logback-classic as we redefine them -->
+                                <filter>
+                                    <artifact>ch.qos.logback:logback-classic</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/services/**</exclude>
+                                    </excludes>
+                                </filter>
                             </filters>
 
                             <relocations>

--- a/tomcat85/pom.xml
+++ b/tomcat85/pom.xml
@@ -78,6 +78,14 @@
                                         <exclude>META-INF/services/**</exclude>
                                     </excludes>
                                 </filter>
+
+                                <!-- Exclude services from logback-classic as we redefine them -->
+                                <filter>
+                                    <artifact>ch.qos.logback:logback-classic</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/services/**</exclude>
+                                    </excludes>
+                                </filter>
                             </filters>
 
                             <relocations>

--- a/tomcat9/pom.xml
+++ b/tomcat9/pom.xml
@@ -78,6 +78,14 @@
                                         <exclude>META-INF/services/**</exclude>
                                     </excludes>
                                 </filter>
+
+                                <!-- Exclude services from logback-classic as we redefine them -->
+                                <filter>
+                                    <artifact>ch.qos.logback:logback-classic</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/services/**</exclude>
+                                    </excludes>
+                                </filter>
                             </filters>
 
                             <relocations>


### PR DESCRIPTION
Logback introduced a servlet initializer.  Since we run at tomcat isolated classloader and we do not reload, we need to exclude this. Fixes #146 