### PR TITLE
[services] Remove service override as not needed in this classloader

### DIFF
--- a/src/assembly/services/org.apache.commons.logging.LogFactory
+++ b/src/assembly/services/org.apache.commons.logging.LogFactory
@@ -1,5 +1,0 @@
-org.apache.juli.logging.impl.SLF4JLogFactory
-
-# Axis gets at JCL through its own mechanism as defined by Commons Discovery, which
-# in turn follows the instructions found at:
-# http://java.sun.com/j2se/1.3/docs/guide/jar/jar.html#Service Provider

--- a/tomcat6/pom.xml
+++ b/tomcat6/pom.xml
@@ -85,7 +85,7 @@
                                     </includes>
                                 </filter>
 
-                                <!-- Exclude services from jcl-over-slf4j as we redefine them -->
+                                <!-- Exclude services from jcl-over-slf4j as not needed in this classloader -->
                                 <filter>
                                     <artifact>org.slf4j:jcl-over-slf4j</artifact>
                                     <excludes>
@@ -137,10 +137,6 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
                                     <resource>META-INF/LICENSE-tomcat.txt</resource>
                                     <file>${main.basedir}/src/assembly/LICENSE-tomcat.txt</file>
-                                </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
-                                    <resource>META-INF/services/org.apache.commons.logging.LogFactory</resource>
-                                    <file>${main.basedir}/src/assembly/services/org.apache.commons.logging.LogFactory</file>
                                 </transformer>
                             </transformers>
                         </configuration>

--- a/tomcat7/pom.xml
+++ b/tomcat7/pom.xml
@@ -83,7 +83,7 @@
                                     </includes>
                                 </filter>
 
-                                <!-- Exclude services from jcl-over-slf4j as we redefine them -->
+                                <!-- Exclude services from jcl-over-slf4j as not needed in this classloader -->
                                 <filter>
                                     <artifact>org.slf4j:jcl-over-slf4j</artifact>
                                     <excludes>
@@ -91,7 +91,7 @@
                                     </excludes>
                                 </filter>
 
-                                <!-- Exclude services from logback-classic as we redefine them -->
+                                <!-- Exclude services from logback-classic as not needed in this classloader -->
                                 <filter>
                                     <artifact>ch.qos.logback:logback-classic</artifact>
                                     <excludes>
@@ -143,10 +143,6 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
                                     <resource>META-INF/LICENSE-tomcat.txt</resource>
                                     <file>${main.basedir}/src/assembly/LICENSE-tomcat.txt</file>
-                                </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
-                                    <resource>META-INF/services/org.apache.commons.logging.LogFactory</resource>
-                                    <file>${main.basedir}/src/assembly/services/org.apache.commons.logging.LogFactory</file>
                                 </transformer>
                             </transformers>
                         </configuration>

--- a/tomcat8/pom.xml
+++ b/tomcat8/pom.xml
@@ -83,7 +83,7 @@
                                     </includes>
                                 </filter>
 
-                                <!-- Exclude services from jcl-over-slf4j as we redefine them -->
+                                <!-- Exclude services from jcl-over-slf4j as not needed in this classloader-->
                                 <filter>
                                     <artifact>org.slf4j:jcl-over-slf4j</artifact>
                                     <excludes>
@@ -91,7 +91,7 @@
                                     </excludes>
                                 </filter>
 
-                                <!-- Exclude services from logback-classic as we redefine them -->
+                                <!-- Exclude services from logback-classic as not needed in this classloader -->
                                 <filter>
                                     <artifact>ch.qos.logback:logback-classic</artifact>
                                     <excludes>
@@ -143,10 +143,6 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
                                     <resource>META-INF/LICENSE-tomcat.txt</resource>
                                     <file>${main.basedir}/src/assembly/LICENSE-tomcat.txt</file>
-                                </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
-                                    <resource>META-INF/services/org.apache.commons.logging.LogFactory</resource>
-                                    <file>${main.basedir}/src/assembly/services/org.apache.commons.logging.LogFactory</file>
                                 </transformer>
                             </transformers>
                         </configuration>

--- a/tomcat85/pom.xml
+++ b/tomcat85/pom.xml
@@ -83,7 +83,7 @@
                                     </includes>
                                 </filter>
 
-                                <!-- Exclude services from jcl-over-slf4j as we redefine them -->
+                                <!-- Exclude services from jcl-over-slf4j as not needed in this classloader -->
                                 <filter>
                                     <artifact>org.slf4j:jcl-over-slf4j</artifact>
                                     <excludes>
@@ -91,7 +91,7 @@
                                     </excludes>
                                 </filter>
 
-                                <!-- Exclude services from logback-classic as we redefine them -->
+                                <!-- Exclude services from logback-classic as not needed in this classloader -->
                                 <filter>
                                     <artifact>ch.qos.logback:logback-classic</artifact>
                                     <excludes>
@@ -143,10 +143,6 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
                                     <resource>META-INF/LICENSE-tomcat.txt</resource>
                                     <file>${main.basedir}/src/assembly/LICENSE-tomcat.txt</file>
-                                </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
-                                    <resource>META-INF/services/org.apache.commons.logging.LogFactory</resource>
-                                    <file>${main.basedir}/src/assembly/services/org.apache.commons.logging.LogFactory</file>
                                 </transformer>
                             </transformers>
                         </configuration>

--- a/tomcat9/pom.xml
+++ b/tomcat9/pom.xml
@@ -83,7 +83,7 @@
                                     </includes>
                                 </filter>
 
-                                <!-- Exclude services from jcl-over-slf4j as we redefine them -->
+                                <!-- Exclude services from jcl-over-slf4j as not needed in this classloader -->
                                 <filter>
                                     <artifact>org.slf4j:jcl-over-slf4j</artifact>
                                     <excludes>
@@ -91,7 +91,7 @@
                                     </excludes>
                                 </filter>
 
-                                <!-- Exclude services from logback-classic as we redefine them -->
+                                <!-- Exclude services from logback-classic as not needed in this classloader -->
                                 <filter>
                                     <artifact>ch.qos.logback:logback-classic</artifact>
                                     <excludes>
@@ -143,10 +143,6 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
                                     <resource>META-INF/LICENSE-tomcat.txt</resource>
                                     <file>${main.basedir}/src/assembly/LICENSE-tomcat.txt</file>
-                                </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
-                                    <resource>META-INF/services/org.apache.commons.logging.LogFactory</resource>
-                                    <file>${main.basedir}/src/assembly/services/org.apache.commons.logging.LogFactory</file>
                                 </transformer>
                             </transformers>
                         </configuration>


### PR DESCRIPTION
An axis override was added at some point probably for consistancy.  After review though and prior issue over a year ago, it is clear this is not right place for this.  Per #72, our inclussion required it to be overridden to fix.  Or in the proper classloader, jcl needed added which would then override setting here.  The technicality of this here is wrong to start with.  The usage we have should have renamed file as 'org.apache.juli.logging.LogFactory' and as such it would never be picked up by axis anyways.  I did backup a branch on my fork just in case this is incorrect assumption but I believe presense of this actually breaks axis as described until jcl added on that end or override used meaning our usage was just plan invalid.  