### PR TITLE
Fixed startup failure in Windows if file path contains spaces

### DIFF
--- a/src/assembly/bin/setenv.bat
+++ b/src/assembly/bin/setenv.bat
@@ -10,4 +10,4 @@
 @REM Contributors: Tomcat-Slf4j-Logback Team.
 @REM
 
-set JAVA_OPTS=%JAVA_OPTS% -Djuli-logback.configurationFile=%CATALINA_HOME%\conf\logback.xml
+set JAVA_OPTS=%JAVA_OPTS% -Djuli-logback.configurationFile="%CATALINA_HOME%\conf\logback.xml"


### PR DESCRIPTION
In Windows, the path must be quoted, because spaces can be included in the install directory name. The above commit adds quotes to the file path.