### PR TITLE
[pom] Add missing classes for tomcat 9.0.1

### DIFF
--- a/tomcat9/pom.xml
+++ b/tomcat9/pom.xml
@@ -79,6 +79,10 @@
                                     <includes>
                                         <include>org/apache/juli/ClassLoaderLogManager**</include>
                                         <include>org/apache/juli/WebappProperties.class</include>
+                                        <include>org/apache/juli/AsyncFileHandler*.class</include>
+                                        <include>org/apache/juli/FileHandler*.class</include>
+                                        <include>org/apache/juli/OneLineFormatter*.class</include>
+                                        <include>org/apache/juli/DateFormatCache*.class</include>
                                         <include>META-INF/NOTICE</include>
                                     </includes>
                                 </filter>


### PR DESCRIPTION
@hazendaz please check this PR - it removes `NoClassDefFound` exceptions, but I see additional files like:
```
09:22 $ ll logs/
total 24
-rw-r-----. 1 ggrzybek ggrzybek    0 10-06 09:20 catalina.2017-10-06.log
-rw-r-----. 1 ggrzybek ggrzybek 8502 10-06 09:22 catalina.log
-rw-r-----. 1 ggrzybek ggrzybek 3678 10-06 09:22 catalina.out
-rw-r-----. 1 ggrzybek ggrzybek    0 10-06 09:20 host-manager.2017-10-06.log
-rw-r-----. 1 ggrzybek ggrzybek    0 10-06 09:20 host-manager.log
-rw-r-----. 1 ggrzybek ggrzybek    0 10-06 09:20 localhost.2017-10-06.log
-rw-r-----. 1 ggrzybek ggrzybek 3980 10-06 09:23 localhost-access.log
-rw-r-----. 1 ggrzybek ggrzybek 1217 10-06 09:23 localhost.log
-rw-r-----. 1 ggrzybek ggrzybek    0 10-06 09:20 manager.2017-10-06.log
-rw-r-----. 1 ggrzybek ggrzybek    0 10-06 09:20 manager.log
```

I'm not sure if anything more has to be done...