### PR TITLE
Patches for slf4j 1.8.x service loader usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <logback.version>1.3.0-alpha4</logback.version>
-        <slf4j.version>1.8.0-beta2</slf4j.version>
+        <slf4j.version>1.8.0-beta4</slf4j.version>
     </properties>
 
     <dependencies>

--- a/tomcat7/pom.xml
+++ b/tomcat7/pom.xml
@@ -3,7 +3,7 @@
 
     Tomcat-Slf4j-Logback (https://github.com/tomcat-slf4j-logback/tomcat-slf4j-logback/)
 
-    Copyright (c) 2010-2018 Tomcat-Slf4j-Logback.
+    Copyright (c) 2010-2019 Tomcat-Slf4j-Logback.
 
     All rights reserved. This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available
@@ -91,11 +91,11 @@
                                     </excludes>
                                 </filter>
 
-                                <!-- Exclude services from logback-classic as not needed in this classloader -->
+                                <!-- Exclude 'ServletContainerInitializer' service from logback-classic as not needed in this classloader -->
                                 <filter>
                                     <artifact>ch.qos.logback:logback-classic</artifact>
                                     <excludes>
-                                        <exclude>META-INF/services/**</exclude>
+                                        <exclude>META-INF/services/javax.servlet.ServletContainerInitializer</exclude>
                                     </excludes>
                                 </filter>
                             </filters>
@@ -128,6 +128,7 @@
                             </relocations>
 
                             <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
                                     <resource>META-INF/LICENSE</resource>
                                     <file>${main.basedir}/LICENSE</file>

--- a/tomcat85/pom.xml
+++ b/tomcat85/pom.xml
@@ -91,11 +91,11 @@
                                     </excludes>
                                 </filter>
 
-                                <!-- Exclude services from logback-classic as not needed in this classloader -->
+                                <!-- Exclude 'ServletContainerInitializer' service from logback-classic as not needed in this classloader -->
                                 <filter>
                                     <artifact>ch.qos.logback:logback-classic</artifact>
                                     <excludes>
-                                        <exclude>META-INF/services/**</exclude>
+                                        <exclude>META-INF/services/javax.servlet.ServletContainerInitializer</exclude>
                                     </excludes>
                                 </filter>
                             </filters>
@@ -128,6 +128,7 @@
                             </relocations>
 
                             <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
                                     <resource>META-INF/LICENSE</resource>
                                     <file>${main.basedir}/LICENSE</file>

--- a/tomcat9/pom.xml
+++ b/tomcat9/pom.xml
@@ -91,11 +91,11 @@
                                     </excludes>
                                 </filter>
 
-                                <!-- Exclude services from logback-classic as not needed in this classloader -->
+                                <!-- Exclude 'ServletContainerInitializer' service from logback-classic as not needed in this classloader -->
                                 <filter>
                                     <artifact>ch.qos.logback:logback-classic</artifact>
                                     <excludes>
-                                        <exclude>META-INF/services/**</exclude>
+                                        <exclude>META-INF/services/javax.servlet.ServletContainerInitializer</exclude>
                                     </excludes>
                                 </filter>
                             </filters>
@@ -128,6 +128,7 @@
                             </relocations>
 
                             <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
                                     <resource>META-INF/LICENSE</resource>
                                     <file>${main.basedir}/LICENSE</file>


### PR DESCRIPTION
releases pushed to central as well for 9.0.14 and 8.5.37 due to break in usage.